### PR TITLE
Adding diskord and ui to REPL global scope

### DIFF
--- a/jishaku/repl/repl_builtins.py
+++ b/jishaku/repl/repl_builtins.py
@@ -92,7 +92,9 @@ def get_var_dict_from_ctx(ctx: commands.Context, prefix: str = '_'):
         'http_post_bytes': http_post_bytes,
         'http_post_json': http_post_json,
         'message': ctx.message,
-        'msg': ctx.message
+        'msg': ctx.message,
+        "diskord": diskord,
+        "ui": diskord.ui,
     }
 
     return {f'{prefix}{k}': v for k, v in raw_var_dict.items()}


### PR DESCRIPTION
Adds `diskord` and `ui` to the default global scope of the REPL. 

- Personally, i use `discord`/`diskord` all the time so i thought it would be easier if it was in the global scope by default.
- Added `ui` to it since writing `class View(ui.View)` seemed easier than `class View(diskord.ui.View)` 